### PR TITLE
Allow installer.py to be loaded as a module

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -366,5 +366,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-else:
-    main()


### PR DESCRIPTION
Don't run main() if we run `import installer` from another script. This allows us to use this file as a library.