### PR TITLE
ECS-58

### DIFF
--- a/templates/component/component_template/corelight-ecs-component-protocol_log-mappings.json
+++ b/templates/component/component_template/corelight-ecs-component-protocol_log-mappings.json
@@ -7,7 +7,7 @@
     "settings": {
       "index": {
         "analysis": {
-          "analyzer": {
+         "analyzer": {
             "es_stk_analyzer": {
               "char_filter": [
                 "whitespace_no_way"
@@ -1200,6 +1200,10 @@
               "type": "long"
             },
             "top_level_domain": {
+              "ignore_above": 32000,
+              "type": "keyword"
+            },
+            "top_level_domain_noport": {
               "ignore_above": 32000,
               "type": "keyword"
             },


### PR DESCRIPTION
Added fields to support ECS-58 - destination.top_level_domain_noport if logstash pipeline 8117-corelight-ecs-remove-port-domain-url.conf.disable is enabled it will create new fields with noport with the domain/url with out a port